### PR TITLE
Use a c-extension instead

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,14 @@
 from os.path import exists
 from setuptools import setup
+from setuptools.extension import Extension
 
 packages = ['shmarray']
 version = '0.0.1'
+
+
+extensions = [Extension("shmarray.shmbuffer",
+                        ['shmarray/shmbuffer.c'])
+              ]
 
 setup(name='shmarray',
       version='0.0.1',
@@ -13,4 +19,5 @@ setup(name='shmarray',
       packages=packages,
       long_description=(open('README.rst').read() if exists('README.rst')
                         else ''),
+      ext_modules=extensions,
       zip_safe=False)

--- a/shmarray/__init__.py
+++ b/shmarray/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
-from .core import unlink, shmarray
+from .core import shmarray
+from .shmbuffer import shmbuffer
 
 __version__ = '0.0.1'

--- a/shmarray/core.py
+++ b/shmarray/core.py
@@ -1,92 +1,6 @@
-import ctypes.util
-import os
-import mmap
-from numbers import Integral
-
 import numpy as np
 
-
-libc_path = ctypes.util.find_library('libc')
-libc = ctypes.CDLL(libc_path)
-
-shm_open = libc.shm_open
-shm_open.argtypes = ctypes.c_char_p, ctypes.c_int, ctypes.c_int
-shm_open.restype = ctypes.c_int
-
-shm_unlink = libc.shm_unlink
-shm_unlink.argtypes = (ctypes.c_char_p,)
-shm_unlink.restype = ctypes.c_int
-
-ftruncate = libc.ftruncate
-ftruncate.argtypes = ctypes.c_int, ctypes.c_int
-ftruncate.restype = ctypes.c_int
-
-
-def cerror(msg):
-    errno = ctypes.get_errno()
-    raise ValueError("%s\n"
-                     "errno: %d\n"
-                     "msg: %s" % (msg, errno, os.strerror(errno)))
-
-
-def unlink(name):
-    if not isinstance(name, str):
-        raise TypeError("name must be a string")
-    o = shm_unlink(name.encode())
-    if o < 0:
-        cerror("Failed to remove shm path: %r" % name)
-
-
-class shmbuffer(mmap.mmap):
-    def __new__(cls, name, nbytes, mode='r+', offset=0):
-        if not isinstance(name, str):
-            raise TypeError("name must be a string")
-
-        if mode == 'r+':
-            flag = os.O_RDWR
-            prot = mmap.PROT_READ | mmap.PROT_WRITE
-            set_nbytes = False
-        elif mode == 'r':
-            flag = os.O_RDONLY
-            prot = mmap.PROT_READ
-            set_nbytes = False
-        elif mode == 'x+':
-            flag = os.O_RDWR | os.O_CREAT | os.O_EXCL
-            prot = mmap.PROT_READ | mmap.PROT_WRITE
-            mode = 'r+'
-            set_nbytes = True
-        else:
-            raise ValueError("Unknown mode: %r" % mode)
-
-        if not isinstance(nbytes, Integral) and nbytes > 0:
-            raise ValueError("nbytes must be an integer > 0")
-        nbytes = int(nbytes)
-
-        fd = shm_open(name.encode(), flag, 0o666)
-        if fd < 0:
-            raise cerror("Failed to create shm file descriptor.")
-
-        if set_nbytes:
-            err = ftruncate(fd, nbytes)
-            if err < 0:
-                raise cerror("Failed to allocate nbytes %d for shm" % nbytes)
-
-        try:
-            obj = mmap.mmap.__new__(cls, fd, nbytes, mmap.MAP_SHARED, prot,
-                                    offset=offset)
-        except Exception:
-            unlink(name)
-            raise
-
-        obj.fd = fd
-        obj.name = name
-        obj.nbytes = nbytes
-        obj.mode = mode
-
-        return obj
-
-    def __reduce__(self):
-        return (shmbuffer, (self.name, self.nbytes, self.mode))
+from .shmbuffer import shmbuffer
 
 
 class shmarray(np.ndarray):
@@ -94,6 +8,7 @@ class shmarray(np.ndarray):
 
     def __new__(subtype, name, shape, dtype=np.uint8, mode='r+', offset=0,
                 order='C'):
+        assert offset == 0
 
         descr = np.dtype(dtype)
         dbytes = descr.itemsize
@@ -103,36 +18,32 @@ class shmarray(np.ndarray):
         size = 1
         for k in shape:
             size *= k
+        nbytes = size * dbytes
 
-        nbytes = offset + size * dbytes
-        start = offset - offset % mmap.ALLOCATIONGRANULARITY
-        nbytes -= start
-        array_offset = offset - start
-
-        buffer = shmbuffer(name, nbytes, mode, offset=start)
+        if mode != 'x+':
+            buffer = shmbuffer(name, mode=mode)
+            if buffer.nbytes != nbytes:
+                raise ValueError("specified shape of %r doesn't match buffer "
+                                 "of size %d" % (shape, buffer.nbytes))
+        else:
+            buffer = shmbuffer(name, nbytes=nbytes, mode=mode)
 
         self = np.ndarray.__new__(subtype, shape, dtype=descr,
-                                  buffer=buffer, offset=array_offset,
-                                  order=order)
+                                  offset=offset, order=order)
         self._shmbuffer = buffer
-        self.offset = offset
 
         return self
 
     def __reduce__(self):
         name = self._shmbuffer.name
-        mode = self._shmbuffer.mode
         order = 'C' if self.flags.carray else 'F'
-        return (shmarray, (name, self.shape, self.dtype, mode,
-                           self.offset, order))
+        return (shmarray, (name, self.shape, self.dtype, 'r+', 0, order))
 
     def __array_finalize__(self, obj):
         if hasattr(obj, '_shmbuffer') and np.may_share_memory(self, obj):
             self._shmbuffer = obj._shmbuffer
-            self.offset = obj.offset
         else:
             self._shmbuffer = None
-            self.offset = None
 
     def __array_wrap__(self, arr, context=None):
         arr = super(shmarray, self).__array_wrap__(arr, context)

--- a/shmarray/core.py
+++ b/shmarray/core.py
@@ -77,9 +77,8 @@ class shmbuffer(mmap.mmap):
         except Exception:
             unlink(name)
             raise
-        finally:
-            os.close(fd)
 
+        obj.fd = fd
         obj.name = name
         obj.nbytes = nbytes
         obj.mode = mode

--- a/shmarray/shmbuffer.c
+++ b/shmarray/shmbuffer.c
@@ -2,6 +2,7 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <string.h>
+#include <stdatomic.h>
 
 #include <Python.h>
 #include "structmember.h"
@@ -26,12 +27,56 @@ typedef struct {
 } shmbuffer_object;
 
 
+typedef struct {
+    atomic_uint refcount;
+    size_t size;
+} shmbuffer_header;
+
+
+static void
+shmbuffer_init(char *buffer, size_t size) {
+    shmbuffer_header *header = (shmbuffer_header *)buffer;
+    header->refcount = ATOMIC_VAR_INIT(1);
+    header->size = size;
+}
+
+
+static unsigned int
+shmbuffer_incref(char *buffer) {
+    shmbuffer_header *header = (shmbuffer_header *)buffer;
+    return atomic_fetch_add(&(header->refcount), 1) + 1;
+}
+
+
+static unsigned int
+shmbuffer_decref(char *buffer) {
+    shmbuffer_header *header = (shmbuffer_header *)buffer;
+    return atomic_fetch_sub(&(header->refcount), 1) - 1;
+}
+
+
+static unsigned int
+shmbuffer_getref(char *buffer) {
+    shmbuffer_header *header = (shmbuffer_header *)buffer;
+    return atomic_load(&(header->refcount));
+}
+
+
+static size_t
+shmbuffer_getsize(char *buffer) {
+    shmbuffer_header *header = (shmbuffer_header *)buffer;
+    return header->size;
+}
+
+
 static void
 shmbuffer_object_dealloc(shmbuffer_object *self)
 {
     if (self->data != NULL) {
+        if (!shmbuffer_decref(self->data)) {
+            shm_unlink(self->name);
+        }
         munmap(self->data, self->size);
-        shm_unlink(self->name);
     }
 
     if (self->weakreflist != NULL)
@@ -54,8 +99,10 @@ shmbuffer_close_method(shmbuffer_object *self, PyObject *unused)
     }
 
     if (self->data != NULL) {
+        if (!shmbuffer_decref(self->data)) {
+            shm_unlink(self->name);
+        }
         munmap(self->data, self->size);
-        shm_unlink(self->name);
         self->data = NULL;
     }
 
@@ -79,6 +126,20 @@ shmbuffer_closed_get(shmbuffer_object *self)
     return PyBool_FromLong(self->data == NULL ? 1 : 0);
 }
 
+static PyObject *
+shmbuffer_refcount_get(shmbuffer_object *self)
+{
+    CHECK_VALID(NULL);
+    return PyLong_FromUnsignedLong(shmbuffer_getref(self->data));
+}
+
+static PyObject *
+shmbuffer_size_get(shmbuffer_object *self)
+{
+    CHECK_VALID(NULL);
+    return PyLong_FromSize_t(self->size);
+}
+
 static struct PyMethodDef shmbuffer_object_methods[] = {
     {"close",     (PyCFunction) shmbuffer_close_method,   METH_NOARGS},
     {NULL, NULL}  /* sentinel */
@@ -86,6 +147,8 @@ static struct PyMethodDef shmbuffer_object_methods[] = {
 
 static PyGetSetDef shmbuffer_object_getset[] = {
     {"closed", (getter) shmbuffer_closed_get, NULL, NULL},
+    {"refcount", (getter) shmbuffer_refcount_get, NULL, NULL},
+    {"size", (getter) shmbuffer_size_get, NULL, NULL},
     {NULL}  /* sentinel */
 };
 
@@ -94,7 +157,9 @@ static int
 shmbuffer_buffer_getbuf(shmbuffer_object *self, Py_buffer *view, int flags)
 {
     CHECK_VALID(-1);
-    if (PyBuffer_FillInfo(view, (PyObject*)self, self->data, self->size,
+    if (PyBuffer_FillInfo(view, (PyObject*)self,
+                          self->data + sizeof(shmbuffer_header),
+                          self->size - sizeof(shmbuffer_header),
                           (self->mode == MODE_READ), flags) < 0)
         return -1;
     self->exports++;
@@ -167,6 +232,9 @@ new_shmbuffer_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
     if (fd < 0)
         return PyErr_SetFromErrnoWithFilename(PyExc_OSError, name);
 
+    /* Include the header in the size */
+    map_size += sizeof(shmbuffer_header);
+
     /* Grow the file if needed */
     if (resize) {
         if (ftruncate(fd, map_size) < 0) {
@@ -178,14 +246,24 @@ new_shmbuffer_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
 
     /* Map it */
     map_addr = mmap(NULL, map_size, prot, MAP_SHARED, fd, 0);
-    close(fd);
     if (map_addr == MAP_FAILED) {
+        close(fd);
         shm_unlink(name);
         return PyErr_SetFromErrnoWithFilename(PyExc_OSError, name);
     }
 
+    /* Initialize if needed */
+    if (resize) {
+        shmbuffer_init(map_addr, map_size);
+    }
+    else {
+        shmbuffer_incref(map_addr);
+    }
+    close(fd);
+
     self = (shmbuffer_object *)type->tp_alloc(type, 0);
     if (self == NULL) {
+        shmbuffer_decref(map_addr);
         munmap(map_addr, map_size);
         shm_unlink(name);
         return NULL;

--- a/shmarray/shmbuffer.c
+++ b/shmarray/shmbuffer.c
@@ -187,7 +187,7 @@ static PyBufferProcs shmbuffer_as_buffer = {
 static Py_ssize_t
 _get_nbytes(PyObject *o)
 {
-    if (o == NULL)
+    if (o == NULL || o == Py_None)
         return 0;
 
     if (!PyIndex_Check(o)) {
@@ -213,7 +213,7 @@ static PyObject *
 new_shmbuffer_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
 {
     shmbuffer_object *self;
-    char *nametemp = NULL, *name = NULL, *mode_str = "x+", *map_addr = NULL;
+    char *nametemp = NULL, *name = NULL, *mode_str = "r+", *map_addr = NULL;
     Py_ssize_t nbytes, map_size;
     PyObject *nbytes_obj = NULL;
     int fd, flags, prot, mode;
@@ -330,7 +330,8 @@ new_shmbuffer_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
     return (PyObject *)self;
 }
 
-PyDoc_STRVAR(shmbuffer_doc, "shmbuffer(name, nbytes, mode='x+'");
+
+PyDoc_STRVAR(shmbuffer_doc, "shmbuffer(name, nbytes=None, mode='r+'");
 
 
 static PyTypeObject shmbuffer_object_type = {

--- a/shmarray/shmbuffer.c
+++ b/shmarray/shmbuffer.c
@@ -1,0 +1,280 @@
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <string.h>
+
+#include <Python.h>
+#include "structmember.h"
+
+
+typedef enum
+{
+    MODE_READ,      /* 'r'  */
+    MODE_READPLUS,  /* 'r+' */
+    MODE_CREATE     /* 'x+' */
+} mode_enum;
+
+
+typedef struct {
+    PyObject_HEAD
+    char *data;
+    char *name;
+    size_t size;
+    int exports;
+    mode_enum mode;
+    PyObject *weakreflist;
+} shmbuffer_object;
+
+
+static void
+shmbuffer_object_dealloc(shmbuffer_object *self)
+{
+    if (self->data != NULL) {
+        munmap(self->data, self->size);
+        shm_unlink(self->name);
+    }
+
+    if (self->weakreflist != NULL)
+        PyObject_ClearWeakRefs((PyObject *) self);
+
+    if (self->name)
+        PyMem_Free(self->name);
+
+    Py_TYPE(self)->tp_free((PyObject *) self);
+}
+
+
+static PyObject *
+shmbuffer_close_method(shmbuffer_object *self, PyObject *unused)
+{
+    if (self->exports > 0) {
+        PyErr_SetString(PyExc_BufferError,
+                        "cannot close exported pointers exist");
+        return NULL;
+    }
+
+    if (self->data != NULL) {
+        munmap(self->data, self->size);
+        shm_unlink(self->name);
+        self->data = NULL;
+    }
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+
+#define CHECK_VALID(err)                                                \
+do {                                                                    \
+    if (self->data == NULL) {                                           \
+    PyErr_SetString(PyExc_ValueError, "shmbuffer closed or invalid");   \
+    return err;                                                         \
+    }                                                                   \
+} while (0)
+
+
+static PyObject *
+shmbuffer_closed_get(shmbuffer_object *self)
+{
+    return PyBool_FromLong(self->data == NULL ? 1 : 0);
+}
+
+static struct PyMethodDef shmbuffer_object_methods[] = {
+    {"close",     (PyCFunction) shmbuffer_close_method,   METH_NOARGS},
+    {NULL, NULL}  /* sentinel */
+};
+
+static PyGetSetDef shmbuffer_object_getset[] = {
+    {"closed", (getter) shmbuffer_closed_get, NULL, NULL},
+    {NULL}  /* sentinel */
+};
+
+
+static int
+shmbuffer_buffer_getbuf(shmbuffer_object *self, Py_buffer *view, int flags)
+{
+    CHECK_VALID(-1);
+    if (PyBuffer_FillInfo(view, (PyObject*)self, self->data, self->size,
+                          (self->mode == MODE_READ), flags) < 0)
+        return -1;
+    self->exports++;
+    return 0;
+}
+
+
+static void
+shmbuffer_buffer_releasebuf(shmbuffer_object *self, Py_buffer *view)
+{
+    self->exports--;
+}
+
+
+static PyBufferProcs shmbuffer_as_buffer = {
+    (getbufferproc)shmbuffer_buffer_getbuf,
+    (releasebufferproc)shmbuffer_buffer_releasebuf,
+};
+
+
+static PyObject *
+new_shmbuffer_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
+{
+    shmbuffer_object *self;
+    char *nametemp = NULL, *name = NULL, *mode_str = "x+", *map_addr = NULL;
+    Py_ssize_t map_size;
+    int fd, flags, prot, mode;
+    int resize;
+
+    static char *keywords[] = {"name", "nbytes", "mode", NULL};
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "sn|s", keywords,
+                                     &nametemp, &map_size, &mode_str))
+        return NULL;
+
+    /* Copy the tagname over */
+    name = PyMem_Malloc(strlen(nametemp) + 1);
+    if (name == NULL) {
+        PyErr_NoMemory();
+        return NULL;
+    }
+    strcpy(name, nametemp);
+
+    /* Determine mode, prot, and flag from mode string */
+    if (strcmp(mode_str, "r") == 0) {
+        mode = MODE_READ;
+        prot = PROT_READ;
+        flags = O_RDONLY;
+        resize = 0;
+    }
+    else if (strcmp(mode_str, "r+") == 0) {
+        mode = MODE_READPLUS;
+        prot = PROT_READ | PROT_WRITE;
+        flags = O_RDWR;
+        resize = 0;
+    }
+    else if (strcmp(mode_str, "x+") == 0) {
+        mode = MODE_CREATE;
+        prot = PROT_READ | PROT_WRITE;
+        flags = O_RDWR | O_CREAT | O_EXCL;
+        resize = 1;
+    }
+    else {
+        return PyErr_Format(PyExc_ValueError,
+                            "shmbuffer invalid mode parameter.");
+    }
+
+    /* Open the file descriptor */
+    fd = shm_open(name, flags, 0666);
+    if (fd < 0)
+        return PyErr_SetFromErrnoWithFilename(PyExc_OSError, name);
+
+    /* Grow the file if needed */
+    if (resize) {
+        if (ftruncate(fd, map_size) < 0) {
+            close(fd);
+            shm_unlink(name);
+            return PyErr_SetFromErrnoWithFilename(PyExc_OSError, name);
+        }
+    }
+
+    /* Map it */
+    map_addr = mmap(NULL, map_size, prot, MAP_SHARED, fd, 0);
+    close(fd);
+    if (map_addr == MAP_FAILED) {
+        shm_unlink(name);
+        return PyErr_SetFromErrnoWithFilename(PyExc_OSError, name);
+    }
+
+    self = (shmbuffer_object *)type->tp_alloc(type, 0);
+    if (self == NULL) {
+        munmap(map_addr, map_size);
+        shm_unlink(name);
+        return NULL;
+    }
+
+    self->name = name;
+    self->size = (size_t) map_size;
+    self->weakreflist = NULL;
+    self->exports = 0;
+    self->data = map_addr;
+    self->mode = (mode_enum)mode;
+
+    return (PyObject *)self;
+}
+
+PyDoc_STRVAR(shmbuffer_doc, "shmbuffer(name, nbytes, mode='x+'");
+
+
+static PyTypeObject shmbuffer_object_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "shmbuffer.shmbuffer",                      /* tp_name */
+    sizeof(shmbuffer_object),                   /* tp_size */
+    0,                                          /* tp_itemsize */
+    (destructor) shmbuffer_object_dealloc,      /* tp_dealloc */
+    0,                                          /* tp_print */
+    0,                                          /* tp_getattr */
+    0,                                          /* tp_setattr */
+    0,                                          /* tp_reserved */
+    0,                                          /* tp_repr */
+    0,                                          /* tp_as_number */
+    0,                                          /* tp_as_sequence */
+    0,                                          /* tp_as_mapping */
+    0,                                          /* tp_hash */
+    0,                                          /* tp_call */
+    0,                                          /* tp_str */
+    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_setattro */
+    &shmbuffer_as_buffer,                       /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /* tp_flags */
+    shmbuffer_doc,                              /* tp_doc */
+    0,                                          /* tp_traverse */
+    0,                                          /* tp_clear */
+    0,                                          /* tp_richcompare */
+    offsetof(shmbuffer_object, weakreflist),    /* tp_weaklistoffset */
+    0,                                          /* tp_iter */
+    0,                                          /* tp_iternext */
+    shmbuffer_object_methods,                   /* tp_methods */
+    0,                                          /* tp_members */
+    shmbuffer_object_getset,                    /* tp_getset */
+    0,                                          /* tp_base */
+    0,                                          /* tp_dict */
+    0,                                          /* tp_descr_get */
+    0,                                          /* tp_descr_set */
+    0,                                          /* tp_dictoffset */
+    0,                                          /* tp_init */
+    PyType_GenericAlloc,                        /* tp_alloc */
+    new_shmbuffer_object,                       /* tp_new */
+    PyObject_Del,                               /* tp_free */
+};
+
+
+static struct PyModuleDef shmbuffermodule = {
+    PyModuleDef_HEAD_INIT,
+    "shmbuffer",
+    NULL,
+    -1,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+PyMODINIT_FUNC
+PyInit_shmbuffer(void)
+{
+    PyObject *dict, *module;
+
+    if (PyType_Ready(&shmbuffer_object_type) < 0)
+        return NULL;
+
+    module = PyModule_Create(&shmbuffermodule);
+    if (module == NULL)
+        return NULL;
+    dict = PyModule_GetDict(module);
+    if (!dict)
+        return NULL;
+
+    PyDict_SetItemString(dict, "shmbuffer", (PyObject*) &shmbuffer_object_type);
+
+    return module;
+}


### PR DESCRIPTION
Previously we used ctypes to implement everything. This rewrites using a c-extension for the buffer, allowing for atomic refcounting across processes. Still a WIP.